### PR TITLE
Use uranium-plus for build (#7)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ sudo: required
 language: python
 services:
   - docker
-# before_install:
-#   - docker pull mongo
-#   - docker run -d -p 127.0.0.1:27017:27017 mongo
-#   - doc
 before_script:
   - npm install -g gulp
 python:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,4 @@ RUN npm install -g gulp
 RUN echo "1" > VERSION
 RUN rm -r .git
 RUN python uranium
-RUN python uranium prep_app
 CMD ["python", "/app/bin/gunicorn", "main:app", "-c", "gunicorn_config.py"]

--- a/tycho/tests/routes/test_event.py
+++ b/tycho/tests/routes/test_event.py
@@ -293,7 +293,7 @@ async def test_post_invalid_event_raises_bad_request(event, cli):
 async def test_put_invalid_event_raises_exception(cli):
     resp = await cli.put('/api/v1/event/',
                          headers={"content-type": "application/json"},
-                         data=json.dumps({"event": {"bad_key": "hello"}})
+                         data=json.dumps({"event": {"start_time": "hello"}})
                          )
     assert resp.status == 400
 
@@ -302,7 +302,7 @@ async def test_post_invalid_event_raises_bad_reqeuest(event, cli):
     resp = await cli.post('/api/v1/event/',
                           headers={"content-type": "application/json"},
                           data=json.dumps({"operation": "merge",
-                                           "event": {"bad_key": "hello"}})
+                                           "event": {"start_time": "hello"}})
                           )
     assert resp.status == 400
 

--- a/ubuild.py
+++ b/ubuild.py
@@ -1,34 +1,47 @@
+import os
+import shutil
 import subprocess
-from uranium import current_build
+from uranium import current_build, task_requires
 
-current_build.config.set_defaults({
-    "module": "tycho"
-})
+current_build.packages.install("uranium-plus[vscode]")
+import uranium_plus
 
-current_build.packages.install("orbital-core")
-from orbital_core.build import bootstrap_build
-bootstrap_build(current_build)
+current_build.config.update(
+    {
+        "uranium-plus": {
+            "module": "tycho",
+            "test": {
+                "packages": ["pytest-aiohttp", "pytest-xdist", "gunicorn"]
+            },
+        }
+    }
+)
+
+uranium_plus.bootstrap(current_build)
 
 
-@build.task
+@current_build.task
 def build_statics(build):
-    build.executables.run(["npm", "install", "."])
+    build.executables.run(["npm", "install", build.root])
     build.executables.run(["gulp", "build"])
 
 
-build.tasks.append("main", "build_statics")
+# current_build.tasks.append("main", "build_statics")
 
 
-@build.task
+@current_build.task
 def start_db(build):
     stop_db(build)
-    build.executables.run(["/bin/bash", "-c", (
-        "docker run -p 27017:27017 --name tycho-db"
-        " -d mongo"
-    )])
+    build.executables.run(
+        [
+            "/bin/bash",
+            "-c",
+            ("docker run -p 27017:27017 --name tycho-db" " -d mongo"),
+        ]
+    )
 
 
-@build.task
+@current_build.task
 def stop_db(build):
     # using subprocess.call as we don't want to
     # error out if the container is not running.
@@ -36,10 +49,27 @@ def stop_db(build):
     subprocess.call(["/bin/bash", "-c", "docker rm tycho-db"])
 
 
-build.tasks.prepend("test", "start_db")
-build.tasks.append("test", "stop_db")
+current_build.tasks.prepend("test", "start_db")
+current_build.tasks.append("test", "stop_db")
 
 
-def prep_app(build):
-    """ prep to be run as an app. """
-    build.packages.install("gunicorn")
+@current_build.task
+@task_requires("build_docs")
+def copy_docs(build):
+    """ copy documentation into the application directory. This allows
+    the docs to be packaged with the app itself.
+    """
+    doc_dir = os.path.join(
+        build.root, build.config["uranium-plus"]["module"], "docs"
+    )
+    if os.path.exists(doc_dir):
+        shutil.rmtree(doc_dir)
+    shutil.copytree(
+        os.path.join(build.sandbox_root, "build", "docs"),
+        os.path.join(
+            build.root, build.config["uranium-plus"]["module"], "docs"
+        ),
+    )
+
+
+current_build.tasks.append("main", "copy_docs")


### PR DESCRIPTION
using uranium-plus over orbital_core for
the build process. uranium-plus is a
best practice version of a ubuild file that
will stay compatible with the most recent version
of uranium, reducing our maintenance burden.

Newer versions of transmute no longer reject
keys that are non-existent in the schema, so
we need to refactor tests to use a valid key,
but an invalid value.